### PR TITLE
Site: guard api config setup for local development

### DIFF
--- a/site/.env
+++ b/site/.env
@@ -1,2 +1,0 @@
-PUBLIC_API_URL=http://localhost:8888
-PUBLIC_CONTEXT=dev

--- a/site/plugins/netlify-plugin-config/index.js
+++ b/site/plugins/netlify-plugin-config/index.js
@@ -22,7 +22,7 @@ module.exports = {
     };
 
     for (const key in variables) {
-      contents = contents + `${key}=${variables[key]}\n`
+      contents = contents + `PUBLIC_${key}=${variables[key]}\n`
     }
 
     fs.writeFileSync(filePath, contents, 'utf8');

--- a/site/src/api/shared/config/config.go
+++ b/site/src/api/shared/config/config.go
@@ -23,6 +23,14 @@ func init() {
 		ApiURL:  os.Getenv("PUBLIC_API_URL"),
 		Context: os.Getenv("PUBLIC_CONTEXT"),
 	}
+
+	if conf.ApiURL == "" {
+		conf.ApiURL = os.Getenv("DEPLOY_URL")
+	}
+
+	if conf.Context == "" {
+		conf.Context = os.Getenv("CONTEXT")
+	}
 }
 
 func IsDev() bool {


### PR DESCRIPTION
New config plugin was not working with local development, so this sets up a fallback for that case